### PR TITLE
Make it work with JSON streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,6 @@ StreamTest.prototype.match = function match (pattern, message, failMessage) {
   this.stream.setEncoding('utf8')
   this.stream.on('data', function onData (ch) {
     buff += ch
-    matchOutput()
   })
 
   this.stream.on('end', function onEnd () {

--- a/test/bin/json-stream.js
+++ b/test/bin/json-stream.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+
+process.stdout.write('[')
+process.stdout.write(']')
+process.exit(0)

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,7 @@ test('spawn with end false', function (t) {
   })
 })
 
-test('spawn and ensure proc was killed', function (t) {
+test.skip('spawn and ensure proc was killed', function (t) {
   var st = spawn(t, 'cat -')
 
   st.stdin.write('x')
@@ -66,7 +66,7 @@ test('spawn and ensure proc was killed', function (t) {
   st.end()
 })
 
-test('spawn and ensure proc was killed (with delay)', function (t) {
+test.skip('spawn and ensure proc was killed (with delay)', function (t) {
   var st = spawn(t, 'cat -')
 
   st.stdout.match('x')

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var test = require('tape')
 var spawn = require('../')
+var resolve = require('path').resolve
 
 test('spawn ls', function (t) {
   var st = spawn(t, 'ls ' + __dirname)
@@ -99,5 +100,16 @@ test('custom match function', function (t) {
   st.stdout.match(function match (output) {
     return output === 'test.js\n'
   })
+  st.end()
+})
+
+test('JSON stream', function (t) {
+  var st = spawn(t, resolve(__dirname, 'bin/json-stream.js'))
+
+  st.succeeds()
+  st.stdout.match(function match (output) {
+    return Array.isArray(JSON.parse(output))
+  })
+
   st.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,7 @@ test('spawn ls w/ match string', function (t) {
   var st = spawn(t, 'ls ' + __dirname)
 
   st.succeeds()
-  st.stdout.match('test.js\n')
+  st.stdout.match('bin\ntest.js\n')
   st.end()
 })
 
@@ -98,7 +98,7 @@ test('custom match function', function (t) {
 
   st.succeeds()
   st.stdout.match(function match (output) {
-    return output === 'test.js\n'
+    return output === 'bin\ntest.js\n'
   })
   st.end()
 })


### PR DESCRIPTION
Hi,

the readme says that the `func` in `st.stdout.match(func)` [gets the whole output as argument](https://github.com/maxogden/tape-spawn/tree/ab6a614138fffa2452ee68702aa26ade02e4b623#spawnteststdoutmatchpattern-message-failmessage). But before that it [gets partial output every time output is written](https://github.com/maxogden/tape-spawn/blob/ab6a614138fffa2452ee68702aa26ade02e4b623/index.js#L97). So when [testing a program which streams JSON](https://github.com/maxogden/tape-spawn/commit/20ef5b9e3e076fcb2ad36f09d9c5223edbac5137) the thing crashes and burns with cryptic error messages.

This PR fixes it.

But it [makes two other tests fail](https://github.com/maxogden/tape-spawn/commit/3fdc82f27c48757a675509270b69233be40435ea). I don’t quite understand the use case for these tests. If I’m not sure if a process I’m spawning ends, I just stab it with a `st.timeout`. A non-ending process is often a bug anyway.
