### PR TITLE
Fix race preventing output match and exit code check in same test.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function StreamMatch (t, command, opts) {
   })
 
   function checkDone () {
-    if (self.stdout.pending === 0 && self.stderr.pending === 0) {
+    if (self.opts.exitCode === undefined && self.stdout.pending === 0 && self.stderr.pending === 0) {
       self.proc.kill()
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -101,3 +101,11 @@ test('custom match function', function (t) {
   })
   st.end()
 })
+
+test('match function', function (t) {
+  var st = spawn(t, 'echo one; sleep 0.5; echo two; exit 7')
+
+  st.stdout.match(/^one/)
+  st.exitCode(7)
+  st.end()
+})


### PR DESCRIPTION
When we have no more output matching (with, e.g., st.stdout.match) to
do, we kill the process. However, if the process has not yet
completed, and we have a pending exit code check, the process may be
killed before exiting.  Thus, when we have a pending exit code check,
we don't kill the process, but instead wait for it to exit so we can
check the exit code.